### PR TITLE
Pa11y test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 .DS_Store
+node_modules

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,5 @@
+{
+	"defaults": {
+		"hideElements": ".skip-to"
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+HOST = localhost:4000
+NPM_BIN = ./node_modules/.bin
+export PATH := $(NPM_BIN):$(PATH)
+
+# Install dependencies
+pa11y-install:
+	@echo "Installing pa11y"
+	@npm install pa11y-ci@^0.2
+
+# Run pa11y against the site
+pa11y-test:
+	@echo "Run pa11y test on site"
+	@pa11y-ci --sitemap "http://$(HOST)/sitemap.xml" --sitemap-find "pa11y.github.io/pa11y" --sitemap-replace "$(HOST)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 HOST = localhost:8000
 NPM_BIN = ./node_modules/.bin
 export PATH := $(NPM_BIN):$(PATH)
@@ -12,4 +11,4 @@ pa11y-install:
 # Run pa11y against the site
 pa11y-test:
 	@echo "Run pa11y test on site"
-	@pa11y-ci --sitemap "http://$(HOST)/sitemap.xml" --sitemap-find "^/" --sitemap-replace "http://$(HOST)/"
+	@pa11y-ci --sitemap "http://$(HOST)/sitemap.xml" --sitemap-find "http://docs.cloud.gov.au/" --sitemap-replace "http://$(HOST)/"

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ pa11y-install:
 # Run pa11y against the site
 pa11y-test:
 	@echo "Run pa11y test on site"
-	@pa11y-ci --sitemap "http://$(HOST)/sitemap.xml" --sitemap-find "pa11y.github.io/pa11y" --sitemap-replace "$(HOST)"
+	@pa11y-ci --sitemap "http://$(HOST)/sitemap.xml" --sitemap-find "^/" --sitemap-replace "http://$(HOST)/"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-HOST = localhost:4000
+HOST = localhost:8000
 NPM_BIN = ./node_modules/.bin
 export PATH := $(NPM_BIN):$(PATH)
 
@@ -7,6 +7,7 @@ export PATH := $(NPM_BIN):$(PATH)
 pa11y-install:
 	@echo "Installing pa11y"
 	@npm install pa11y-ci@^0.2
+	@npm install phantomjs
 
 # Run pa11y against the site
 pa11y-test:

--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ The following assumes you have python installed locally.
 * Install dependencies with `pip install -r requirements.txt`
 * `mkdocs serve`
 * browse to http://localhost:4000
+
+## Run accessibility tests using pa11y
+
+Install dependencies with:
+
+`make pa11y-install`
+
+Make sure you have the app running locally with:
+
+`mkdocs serve`
+
+Run the test with:
+
+`make pa11y-test`

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ The following assumes you have python installed locally.
 
 ## Run accessibility tests using pa11y
 
-Install dependencies with:
+Install pa11y and it's dependencies with:
 
 `make pa11y-install`
+
+Make sure you are running the latest dependencies for the app with:
+
+`pip install -r requirements.txt`
 
 Make sure you have the app running locally with:
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,13 +9,12 @@ machine:
     - cf -v
 
 dependencies:
-  pre:
-  - make pa11y-install
-  cache_directories:
-    - "node_modules"
   override:
     - pip install mkdocs
     - pip install -r requirements.txt
+    - make pa11y-install
+    cache_directories:
+      - "node_modules"
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  node:
+    version: 6.8.1
   python:
     version: 2.7.11
   post:
@@ -7,13 +9,18 @@ machine:
     - cf -v
 
 dependencies:
+  pre:
+  - make install
+  cache_directories:
+    - "node_modules"
   override:
     - pip install mkdocs
-    - pip install mkdocs-gov-au-theme 
+    - pip install mkdocs-gov-au-theme
 
 test:
   override:
     - mkdocs build
+    - make test
 
 deployment:
   alpha:

--- a/circle.yml
+++ b/circle.yml
@@ -20,8 +20,8 @@ dependencies:
 test:
   override:
     - mkdocs build
-    - mkdocs serve
-      background: true
+    - mkdocs serve:
+        background: true
     - sleep 5
     - make pa11y-test
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
 
 dependencies:
   pre:
-  - make install
+  - make pa11y-install
   cache_directories:
     - "node_modules"
   override:
@@ -20,7 +20,7 @@ dependencies:
 test:
   override:
     - mkdocs build
-    - make test
+    - make pa11y-test
 
 deployment:
   alpha:

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,9 @@ dependencies:
 test:
   override:
     - mkdocs build
+    - mkdocs serve
+        background: true
+    - sleep 5
     - make pa11y-test
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ test:
   override:
     - mkdocs build
     - mkdocs serve
-        background: true
+      background: true
     - sleep 5
     - make pa11y-test
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
     - "node_modules"
   override:
     - pip install mkdocs
-    - pip install mkdocs-gov-au-theme
+    - pip install -r requirements.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     - pip install mkdocs
     - pip install -r requirements.txt
     - make pa11y-install
-    cache_directories:
+  cache_directories:
       - "node_modules"
 
 test:

--- a/docs/usage/cfcli/application_delete.md
+++ b/docs/usage/cfcli/application_delete.md
@@ -2,7 +2,7 @@
 
 To get a list of existing apps deployed in the curent space run `cf apps`.
 
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf apps
 Getting apps in org dto / space dtoweb as example.person@digital.gov.au...
@@ -19,7 +19,7 @@ lunix@boran]  (master) ->
 To delete an application from the platform is `cf delete <appname>`  
 You should be very careful here - _measure twice - cut once !_
 
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf delete mydemoapp
 

--- a/docs/usage/cfcli/application_delete.md
+++ b/docs/usage/cfcli/application_delete.md
@@ -2,7 +2,7 @@
 
 To get a list of existing apps deployed in the curent space run `cf apps`.
 
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf apps
 Getting apps in org dto / space dtoweb as example.person@digital.gov.au...
@@ -19,7 +19,7 @@ lunix@boran]  (master) ->
 To delete an application from the platform is `cf delete <appname>`  
 You should be very careful here - _measure twice - cut once !_
 
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf delete mydemoapp
 

--- a/docs/usage/cfcli/application_deployment.md
+++ b/docs/usage/cfcli/application_deployment.md
@@ -8,7 +8,7 @@ There is a fair amount of options available to the `cf push` command. To see the
 
 Let's push our demo application now to the platform.
 
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/pcf_demo_app]
 lunix@boran]  (master) -> cf push mydemoapp -b staticfile_buildpack -n mydemoapp -i 1 -m 64M -k 256M
 ...
@@ -23,7 +23,7 @@ There is a bit going on here. Lets run throught what the options are:
 **-k** :sets the maximum DISK usage for our application (e.g. 256M, 1024M, 1G)  
 
 Lets see this in action.
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/pcf_demo_app]
 lunix@boran]  (master) -> cf push mydemoapp -b staticfile_buildpack -n mydemoapp -i 1 -m 64M -k 256M
 Creating app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...

--- a/docs/usage/cfcli/application_deployment.md
+++ b/docs/usage/cfcli/application_deployment.md
@@ -8,7 +8,7 @@ There is a fair amount of options available to the `cf push` command. To see the
 
 Let's push our demo application now to the platform.
 
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/pcf_demo_app]
 lunix@boran]  (master) -> cf push mydemoapp -b staticfile_buildpack -n mydemoapp -i 1 -m 64M -k 256M
 ...
@@ -23,7 +23,7 @@ There is a bit going on here. Lets run throught what the options are:
 **-k** :sets the maximum DISK usage for our application (e.g. 256M, 1024M, 1G)  
 
 Lets see this in action.
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/pcf_demo_app]
 lunix@boran]  (master) -> cf push mydemoapp -b staticfile_buildpack -n mydemoapp -i 1 -m 64M -k 256M
 Creating app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...

--- a/docs/usage/cfcli/index.md
+++ b/docs/usage/cfcli/index.md
@@ -6,6 +6,6 @@ This article is intended for developers new to the DTO Platform, herin called 'T
 
 This tutorial assumes that you have already been sent your account details for The Platform and you have a copy of the demo application cloned locally.
 
-``` language-html
+``` language-none
 git clone git@github.com:AusDTO/pcf_demo_app.git
 ```

--- a/docs/usage/cfcli/index.md
+++ b/docs/usage/cfcli/index.md
@@ -6,6 +6,6 @@ This article is intended for developers new to the DTO Platform, herin called 'T
 
 This tutorial assumes that you have already been sent your account details for The Platform and you have a copy of the demo application cloned locally.
 
-``` bash
+``` language-html
 git clone git@github.com:AusDTO/pcf_demo_app.git
 ```

--- a/docs/usage/cfcli/log_access.md
+++ b/docs/usage/cfcli/log_access.md
@@ -8,7 +8,7 @@ This will tail the application logs, from all Application Instances, straight to
 You can test it by opening up your browser and accessing [http://mydemoapp.apps.staging.digital.gov.au](http://mydemoapp.apps.staging.digital.gov.au).
 This will produce the following output:
 
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf logs mydemoapp
 Connected, tailing logs for app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...
@@ -31,7 +31,7 @@ lunix@boran]  (master) ->
 
 To see logs from the past:
 
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf logs --recent mydemoapp
 Connected, dumping recent logs for app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...

--- a/docs/usage/cfcli/log_access.md
+++ b/docs/usage/cfcli/log_access.md
@@ -8,7 +8,7 @@ This will tail the application logs, from all Application Instances, straight to
 You can test it by opening up your browser and accessing [http://mydemoapp.apps.staging.digital.gov.au](http://mydemoapp.apps.staging.digital.gov.au).
 This will produce the following output:
 
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf logs mydemoapp
 Connected, tailing logs for app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...
@@ -31,7 +31,7 @@ lunix@boran]  (master) ->
 
 To see logs from the past:
 
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/demo-app]
 lunix@boran]  (master) -> cf logs --recent mydemoapp
 Connected, dumping recent logs for app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...

--- a/docs/usage/cfcli/login.md
+++ b/docs/usage/cfcli/login.md
@@ -2,7 +2,7 @@
 
 Before working with The Platform you need to instruct the cf cli what platform API endpoint, organisation & space to work with and what your credentials are. If you only belong to one ORG and/or space then these will be auto-selected for you.
 
-``` language-html
+``` language-none
 [~/src/github.com/AusDTO/ops/sekrets]
 lunix@boran]  (master) -> cf login -a https://api.system.staging.digital.gov.au --skip-ssl-validation
 API endpoint: https://api.system.staging.digital.gov.au

--- a/docs/usage/cfcli/login.md
+++ b/docs/usage/cfcli/login.md
@@ -2,7 +2,7 @@
 
 Before working with The Platform you need to instruct the cf cli what platform API endpoint, organisation & space to work with and what your credentials are. If you only belong to one ORG and/or space then these will be auto-selected for you.
 
-``` bash
+``` language-html
 [~/src/github.com/AusDTO/ops/sekrets]
 lunix@boran]  (master) -> cf login -a https://api.system.staging.digital.gov.au --skip-ssl-validation
 API endpoint: https://api.system.staging.digital.gov.au

--- a/docs/usage/requesting_access.md
+++ b/docs/usage/requesting_access.md
@@ -4,7 +4,7 @@ _Before requesting access to cloud.gov.au each team member should create an acco
 
 If you would like to make use of cloud.gov.au to develop your transformation's Alpha then please send an email to `support@cloud.gov.au` using the following template:
 
-``` language-html
+``` language-none
 G`Day cloud.gov.au team !
 
 We are excited to be starting the Alpha of our digital transformation this week.

--- a/docs/usage/requesting_access.md
+++ b/docs/usage/requesting_access.md
@@ -3,12 +3,8 @@
 _Before requesting access to cloud.gov.au each team member should create an account on github, if they have not already._
 
 If you would like to make use of cloud.gov.au to develop your transformation's Alpha then please send an email to `support@cloud.gov.au` using the following template:
-<br />
-<br />
-<br />
-<br />
 
-``` text
+``` language-html
 G`Day cloud.gov.au team !
 
 We are excited to be starting the Alpha of our digital transformation this week.

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -29,7 +29,7 @@ The DTO has produced a rubygem, `jalpha`, for scaffolding out an opinionated Jek
 * follow your new github repo
 * add some environment variables via the circleci UI
 
-``` language-html
+``` language-none
 CF_API
 CF_ORG
 CF_PASSWORD

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -28,7 +28,8 @@ The DTO has produced a rubygem, `jalpha`, for scaffolding out an opinionated Jek
 * go to circleci in the browser and authorize with Github.
 * follow your new github repo
 * add some environment variables via the circleci UI
-```
+
+``` language-html
 CF_API
 CF_ORG
 CF_PASSWORD
@@ -37,5 +38,3 @@ CF_USER
 CF_BASIC_AUTH_USERNAME  [optional]
 CF_BASIC_AUTH_PASSWORD  [optional]
 ```
-
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: cloud.gov.au
+site_url: http://docs.cloud.gov.au
 site_description: "Documentation for users of cloud.gov.au"
 theme: gov-au-theme
 extra:
@@ -15,19 +16,19 @@ pages:
       - 'Requesting Access': 'usage/requesting_access.md'
       - 'Setup': 'usage/setup.md'
       - 'Sending Emails': 'usage/sending_emails.md'
-      - CF-CLI:
-        - 'Intro': usage/cfcli/index.md
-        - 'Install': usage/cfcli/install.md
-        - 'Login': usage/cfcli/login.md
-        - 'Application Deployment': usage/cfcli/application_deployment.md
-        - 'Application Deletion': usage/cfcli/application_delete.md
-        - 'Log Access': usage/cfcli/log_access.md
       - 'Your First Deploy': 'usage/your_first_deploy.md'
       - 'Getting your app ready for launch': 'usage/orca.md'
+  - CF-CLI:
+    - 'Intro': usage/cfcli/index.md
+    - 'Install': usage/cfcli/install.md
+    - 'Login': usage/cfcli/login.md
+    - 'Application Deployment': usage/cfcli/application_deployment.md
+    - 'Application Deletion': usage/cfcli/application_delete.md
+    - 'Log Access': usage/cfcli/log_access.md
   - Support:
     - 'Incident response': 'support/incident_response.md'
-    - 'Incident reports':
-      - 'Intro': 'support/incident_reports/index.md'
-      - '2016-08-12': 'support/incident_reports/2016-08-12.md'
-      - '2016-06-05': 'support/incident_reports/2016-06-05.md'
-      - '2016-02-11': 'support/incident_reports/2016-02-11.md'
+  - 'Incident reports':
+    - 'Intro': 'support/incident_reports/index.md'
+    - '2016-08-12': 'support/incident_reports/2016-08-12.md'
+    - '2016-06-05': 'support/incident_reports/2016-06-05.md'
+    - '2016-02-11': 'support/incident_reports/2016-02-11.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,11 +13,11 @@ markdown_extensions:
 pages:
   - Home: index.md
   - Usage:
-      - 'Requesting Access': 'usage/requesting_access.md'
-      - 'Setup': 'usage/setup.md'
-      - 'Sending Emails': 'usage/sending_emails.md'
-      - 'Your First Deploy': 'usage/your_first_deploy.md'
-      - 'Getting your app ready for launch': 'usage/orca.md'
+    - 'Requesting Access': 'usage/requesting_access.md'
+    - 'Setup': 'usage/setup.md'
+    - 'Sending Emails': 'usage/sending_emails.md'
+    - 'Your First Deploy': 'usage/your_first_deploy.md'
+    - 'Getting your app ready for launch': 'usage/orca.md'
   - CF-CLI:
     - 'Intro': usage/cfcli/index.md
     - 'Install': usage/cfcli/install.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs-gov-au-theme
+mkdocs-gov-au-theme==0.0.4


### PR DESCRIPTION
This pull request adds automated accessibility testing as part of the deployment process using [pa11y-ci](https://www.npmjs.com/package/pa11y-ci).

I have also added Makefile scripts that allow developers to run accessibility tests locally.

Due to the accessibility tests running on deployment, I needed to fix accessibility issues in the current product. Most of these accessibility issues were amended in the [latest uikit mkdocs theme update](https://github.com/AusDTO/mkdocs-gov-au-theme/releases/tag/0.0.4). Some visual updates were also made to `<code>` blocks as there were colour contrast issues with the current ones.

The work in this PR was influenced by the implementation of pa11y-ci and CircleCI for the [Financial Times Orgiami project](http://jamesloveridge.net/journal/2016/using-pa11y-with-jekyll-and-circleci)
