### PR TITLE
update application deployment and add manifest documnetation

### DIFF
--- a/docs/usage/cfcli/application_deployment.md
+++ b/docs/usage/cfcli/application_deployment.md
@@ -1,97 +1,29 @@
-## Application Deployment
+The command to create a new app and to push a new version of an existing one are the same: `cf push`.
 
-To get a list of existing apps depoloyed in the curent space run `cf apps`.
+Cloud Foundry isn’t version-control-aware. `cf push` will deploy the working state of whatever files you have in your current directory.
 
-The command used for deploying a new app, or for updating an existing app, is `cf push ...`
+Before deploying your application you should [setup a manifest.yml](#). The manifest.yml file tells `cf push` what to do. This includes everything from how many instances to create to how much memory or disk space to assign.
 
-There is a fair amount of options available to the `cf push` command. To see them all run `cf push --help`
+Another option is to define these configurations as options on `cf push`. Not defining configuration options at all may slow down your deployments.
 
-Let's push our demo application now to the platform.
+The basic steps to deploy your application are:
 
-``` language-none
-[~/src/github.com/AusDTO/pcf_demo_app]
-lunix@boran]  (master) -> cf push mydemoapp -b staticfile_buildpack -n mydemoapp -i 1 -m 64M -k 256M
-...
-...
-```
-There is a bit going on here. Lets run throught what the options are:
+1. Check out whatever version of the code you want to deploy.
 
-**-b** :specifiy what buildpack to use to configure the Application Instance  
-**-n** :sets the subdomain under which our application will be available  
-**-i** :sets how many instances are required to serve our application  
-**-m** :sets the maximum RAM usage for our application (e.g. 256M, 1024M, 1G)  
-**-k** :sets the maximum DISK usage for our application (e.g. 256M, 1024M, 1G)  
+        git checkout master
 
-Lets see this in action.
-``` language-none
-[~/src/github.com/AusDTO/pcf_demo_app]
-lunix@boran]  (master) -> cf push mydemoapp -b staticfile_buildpack -n mydemoapp -i 1 -m 64M -k 256M
-Creating app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...
-OK
+2. Target the appropriate organisation/space.
 
-Creating route mydemoapp.apps.staging.digital.gov.au...
-OK
+        cf target -o <SOMEORG> -s <SOMESPACE>
 
-Binding mydemoapp.apps.staging.digital.gov.au to mydemoapp...
-OK
+3. Deploy the application.
 
-Uploading mydemoapp...
-Uploading app files from: /home/lunix/src/github.com/AusDTO/pcf_demo_app
-Uploading 550B, 2 files
-Done uploading
-OK
+        cf push <APPNAME>
 
-Starting app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...
-Creating container
-Successfully created container
-Downloading app package...
-Downloaded app package (518B)
-Downloading buildpacks (staticfile_buildpack)...
-Downloading staticfile_buildpack...
-Downloaded staticfile_buildpack
-Downloaded buildpacks
-Staging...
--------> Buildpack version 1.2.2
-Downloaded [file:///tmp/buildpacks/59f767b9bf9c7cde279cb3b56367792c/dependencies/https___s3.amazonaws.com_pivotal-buildpacks_nginx_cflinuxfs2_nginx-1.8.0-linux-x64.tgz]
-grep: Staticfile: No such file or directory
------> Using root folder
------> Copying project files into public/
------> Setting up nginx
-grep: Staticfile: No such file or directory
-Exit status 0
-Staging complete
-Uploading droplet, build artifacts cache...
-Uploading droplet...
-Uploading build artifacts cache...
-Uploaded build artifacts cache (131B)
-Uploaded droplet (2.4M)
-Uploading complete
+    If your project does not have a manifest.yml or you would like to override any configuration in the project manifest.yml then you should specify deployment configurations at the time of deployment.
 
-1 of 1 instances running
+        cf push -b <BUILDPACK> -n <APPNAME> -i 1 -m 64M -k 256M
 
-App started
+    To view all options run `cf push --help`
 
-
-OK
-
-App mydemoapp was started using this command `sh boot.sh`
-
-Showing health and status for app mydemoapp in org dto / space dtoweb as example.person@digital.gov.au...
-OK
-
-requested state: started
-instances: 1/1
-usage: 64M x 1 instances
-urls: mydemoapp.apps.staging.digital.gov.au
-last uploaded: Mon Feb 15 01:46:56 UTC 2016
-stack: cflinuxfs2
-buildpack: staticfile_buildpack
-
-     state     since                    cpu    memory        disk            details
-#0   running   2016-02-15 12:47:36 PM   0.0%   3.3M of 64M   33.7M of 256M
-
-[~/src/github.com/AusDTO/pcf_demo_app]
-lunix@boran]  (master) ->
-```
-
-With just a single command you should now have your application running on the DTO Platform at [http://mydemoapp.apps.staging.digital.gov.au](http://mydemoapp.apps.staging.digital.gov.au)
+The app should now be live at APPNAME.apps.staging.digital.gov.au.

--- a/docs/usage/cfcli/application_deployment.md
+++ b/docs/usage/cfcli/application_deployment.md
@@ -2,9 +2,9 @@ The command to create a new app and to push a new version of an existing one are
 
 Cloud Foundry isn’t version-control-aware. `cf push` will deploy the working state of whatever files you have in your current directory.
 
-Before deploying your application you should [setup a manifest.yml](#). The manifest.yml file tells `cf push` what to do. This includes everything from how many instances to create to how much memory or disk space to assign.
+Before deploying your application you should [setup a manifest.yml](/usage/create_manifest/). The manifest.yml file tells `cf push` what to do. This includes everything from how many instances to create to how much memory or disk space to assign.
 
-Another option is to define these configurations as options on `cf push`. Not defining configuration options at all may slow down your deployments.
+Another option is to define these configurations as options to `cf push`. Not defining configuration options at all may slow down your deployments or provide too many or too few resources for your application.
 
 The basic steps to deploy your application are:
 

--- a/docs/usage/create_manifest.md
+++ b/docs/usage/create_manifest.md
@@ -1,0 +1,15 @@
+Application manifests tell `cf push` what to do with applications. This includes everything from how many instances to create and how much memory to allocate to what services applications should use.
+
+Here is a basic manifest.yml example for a static site
+
+```
+---
+
+path: _site
+instances: 1
+memory: 64M
+disk_quota: 256M
+buildpack: staticfile_buildpack
+```
+
+You can read more information [how to deploy with application manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html).

--- a/docs/usage/create_manifest.md
+++ b/docs/usage/create_manifest.md
@@ -1,4 +1,4 @@
-Application manifests tell `cf push` what to do with applications. This includes everything from how many instances to create and how much memory to allocate to what services applications should use.
+Application manifests tell `cf push` what to do with applications. This includes information such as disk size and which buildpack to use.
 
 Here is a basic manifest.yml example for a static site
 

--- a/docs/usage/create_manifest.md
+++ b/docs/usage/create_manifest.md
@@ -12,4 +12,4 @@ disk_quota: 256M
 buildpack: staticfile_buildpack
 ```
 
-You can read more information [how to deploy with application manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html).
+Read more about [how to deploy with application manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ pages:
     - 'Getting your app ready for launch': 'usage/orca.md'
   - CF-CLI:
     - 'Intro': usage/cfcli/index.md
+    - 'Create manifest.yml': usage/create_manifest.md
     - 'Application Deployment': usage/cfcli/application_deployment.md
     - 'Application Deletion': usage/cfcli/application_delete.md
     - 'Log Access': usage/cfcli/log_access.md


### PR DESCRIPTION
This PR updates the 'Application deployment' content page. While updating I realised it was important to also add a content page about manifest.yml file. In the future we may have links to example manifests for each stack we document.