### PR TITLE
add setup ci-cd content page

### DIFF
--- a/docs/usage/ci_cd.md
+++ b/docs/usage/ci_cd.md
@@ -7,6 +7,8 @@ The major benefits of Continuous deployment are:
 - reduce complexity, risk and effort of releasing application updates
 - increase the speed you can iterate your application
 
+Some teams choose to continuously deploy application changes straight to production. Other teams choose a Continuous delivery method. This is where application updates are continuously deployed to a development or staging site. There is a manual step to then release these updates from staging to production.
+
 ## How it works
 
 Every time the application codebase changes, a continuous integration service will automatically compile and test your new codebase. If all tests pass it will also deploy the application.
@@ -16,6 +18,6 @@ Currently we use CircleCI as our continuous integration service.
 Follow these steps to setup your application to do continuous deployment on cloud.gov.au
 
 1. [Create a manifest.yml](/usage/create_manifest/)
-2. [Setup CircleCI](#)
+2. [Setup CircleCI](/usage/setup_circle/)
 
 Also consider using zero downtime deploys for you application. cloud.gov.au can do this using Blue/Green deploys.

--- a/docs/usage/ci_cd.md
+++ b/docs/usage/ci_cd.md
@@ -1,0 +1,21 @@
+Continuous deployment allows you to safely automate the testing and deployment of your application. It reduces the risk of manual deployments through repeatable, automated, tested deployments.
+
+The major benefits of Continuous deployment are:
+
+- reduce effort required to test your application
+- more effectively discover and fix problems in your application
+- reduce complexity, risk and effort of releasing application updates
+- increase the speed you can iterate your application
+
+## How it works
+
+Every time the application codebase changes, a continuous integration service will automatically compile and test your new codebase. If all tests pass it will also deploy the application.
+
+Currently we use CircleCI as our continuous integration service.
+
+Follow these steps to setup your application to do continuous deployment on cloud.gov.au
+
+1. [Create a manifest.yml](/usage/create_manifest/)
+2. [Setup CircleCI](#)
+
+Also consider using zero downtime deploys for you application. cloud.gov.au can do this using Blue/Green deploys.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
     - 'Your First Deploy': 'usage/your_first_deploy.md'
     - 'Getting your app ready for launch': 'usage/orca.md'
     - 'Setup CircleCI': 'usage/setup_circle.md'
+    - 'Setup Continuous deployment': 'usage/ci_cd.md'
   - CF-CLI:
     - 'Intro': usage/cfcli/index.md
     - 'Create manifest.yml': usage/create_manifest.md


### PR DESCRIPTION
This content page gives a brief overview of what continuous deployment is and how to set it up. I'm not sure whether we should be using the term Continuous deployment or Continuous delivery here.

There is a link to 'Setup CircleCI' that hasn't been added yet because it is dependent on the' Setup CircleCI' content page getting merged.