### PR TITLE
Discussion: add github repo url?

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ extra:
       'external': 'true'
 markdown_extensions:
   - toc:
+repo_url: https://github.com/AusDTO/cga_docs
 pages:
   - Home: index.md
   - Usage:


### PR DESCRIPTION
Is this something we want to do? I'd like to have the url but I think it might need to go with some changes to the theme. At the moment it's probably not sufficiently distinguished from the rest of the content. Eg the home page:

![image](https://cloud.githubusercontent.com/assets/4583474/20121809/8f89b66c-a667-11e6-92a4-f4469f9067cc.png)
