### PR TITLE
Bump theme version to fix uikit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-gov-au-theme==0.1.0
+mkdocs-gov-au-theme==0.1.1
 mkdocs==0.16.0


### PR DESCRIPTION
The previous theme version relied on linking to uikit's staging site which is no longer available. 