### PR TITLE
Link to the cf-cli instructions

### DIFF
--- a/docs/getting_started/install_cli.md
+++ b/docs/getting_started/install_cli.md
@@ -1,36 +1,6 @@
 abstract: As a user, most of your interactions with Cloud Foundry will be through the command line.
 
-<table class="content-table">
-<thead>
-<tr>
-<th>OS</th>
-<th>32 BIT</th>
-<th>64 BIT</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Windows</td>
-<td><a href="https://cli.run.pivotal.io/stable?release=windows32&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-<td><a href="https://cli.run.pivotal.io/stable?release=windows64&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-</tr>
-<tr>
-<td>Linux (deb)</td>
-<td><a href="https://cli.run.pivotal.io/stable?release=debian32&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-<td><a href="https://cli.run.pivotal.io/stable?release=debian64&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-</tr>
-<tr>
-<td>Linux (rpm)</td>
-<td><a href="https://cli.run.pivotal.io/stable?release=redhat32&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-<td><a href="https://cli.run.pivotal.io/stable?release=redhat64&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-</tr>
-<tr>
-<td>Mac OSX</td>
-<td>na</td>
-<td><a href="https://cli.run.pivotal.io/stable?release=macosx64&amp;version=6.21.1&amp;source=pcf1.6">6.21.1</a></td>
-</tr>
-</tbody>
-</table>
+Install the `cf` command line tool using the instructions at [https://docs.cloudfoundry.org/cf-cli/install-go-cli.html](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html).
 
 Confirm the installation was successful by running:
 


### PR DESCRIPTION
The previous cf-cli versions were quite out of date, so I have removed them and linked to the official cf-cli instructions instead. 